### PR TITLE
Separating graph definition from session

### DIFF
--- a/examples/03_logistic_regression_mnist_sol.py
+++ b/examples/03_logistic_regression_mnist_sol.py
@@ -1,4 +1,4 @@
-""" Simple logistic regression model to solve OCR task 
+""" Simple logistic regression model to solve OCR task
 with MNIST in TensorFlow
 MNIST dataset: yann.lecun.com/exdb/mnist/
 Author: Chip Huyen
@@ -20,14 +20,14 @@ n_epochs = 30
 
 # Step 1: Read in data
 # using TF Learn's built in function to load MNIST data to the folder data/mnist
-mnist = input_data.read_data_sets('/data/mnist', one_hot=True) 
+mnist = input_data.read_data_sets('./data/mnist', one_hot=True)
 
 # Step 2: create placeholders for features and labels
 # each image in the MNIST data is of shape 28*28 = 784
 # therefore, each image is represented with a 1x784 tensor
-# there are 10 classes for each image, corresponding to digits 0 - 9. 
+# there are 10 classes for each image, corresponding to digits 0 - 9.
 # each lable is one hot vector.
-X = tf.placeholder(tf.float32, [batch_size, 784], name='X_placeholder') 
+X = tf.placeholder(tf.float32, [batch_size, 784], name='X_placeholder')
 Y = tf.placeholder(tf.int32, [batch_size, 10], name='Y_placeholder')
 
 # Step 3: create weights and bias
@@ -41,7 +41,7 @@ b = tf.Variable(tf.zeros([1, 10]), name="bias")
 # Step 4: build model
 # the model that returns the logits.
 # this logits will be later passed through softmax layer
-logits = tf.matmul(X, w) + b 
+logits = tf.matmul(X, w) + b
 
 # Step 5: define loss function
 # use cross entropy of softmax of logits as the loss function
@@ -52,19 +52,24 @@ loss = tf.reduce_mean(entropy) # computes the mean over all the examples in the 
 # using gradient descent with learning rate of 0.01 to minimize loss
 optimizer = tf.train.AdamOptimizer(learning_rate).minimize(loss)
 
+# Step 7: Adding testing part to graph to calculate accuracy
+preds = tf.nn.softmax(logits)
+correct_preds = tf.equal(tf.argmax(preds, 1), tf.argmax(Y, 1))
+accuracy = tf.reduce_sum(tf.cast(correct_preds, tf.float32)) # need numpy.count_nonzero(boolarr) :(
+
 with tf.Session() as sess:
 	# to visualize using TensorBoard
 	writer = tf.summary.FileWriter('./graphs/logistic_reg', sess.graph)
 
 	start_time = time.time()
-	sess.run(tf.global_variables_initializer())	
+	sess.run(tf.global_variables_initializer())
 	n_batches = int(mnist.train.num_examples/batch_size)
 	for i in range(n_epochs): # train the model n_epochs times
 		total_loss = 0
 
 		for _ in range(n_batches):
 			X_batch, Y_batch = mnist.train.next_batch(batch_size)
-			_, loss_batch = sess.run([optimizer, loss], feed_dict={X: X_batch, Y:Y_batch}) 
+			_, loss_batch = sess.run([optimizer, loss], feed_dict={X: X_batch, Y:Y_batch})
 			total_loss += loss_batch
 		print('Average loss epoch {0}: {1}'.format(i, total_loss/n_batches))
 
@@ -73,19 +78,15 @@ with tf.Session() as sess:
 	print('Optimization Finished!') # should be around 0.35 after 25 epochs
 
 	# test the model
-	
-	preds = tf.nn.softmax(logits)
-	correct_preds = tf.equal(tf.argmax(preds, 1), tf.argmax(Y, 1))
-	accuracy = tf.reduce_sum(tf.cast(correct_preds, tf.float32)) # need numpy.count_nonzero(boolarr) :(
-	
+
 	n_batches = int(mnist.test.num_examples/batch_size)
 	total_correct_preds = 0
-	
+
 	for i in range(n_batches):
 		X_batch, Y_batch = mnist.test.next_batch(batch_size)
-		accuracy_batch = sess.run([accuracy], feed_dict={X: X_batch, Y:Y_batch}) 
-		total_correct_preds += accuracy_batch	
-	
+		accuracy_batch = sess.run(accuracy, feed_dict={X: X_batch, Y:Y_batch})
+		total_correct_preds += accuracy_batch
+
 	print('Accuracy {0}'.format(total_correct_preds/mnist.test.num_examples))
 
 	writer.close()


### PR DESCRIPTION
Based on the course contents, definition of TensorFlow graph should be separate from running the session.

The MNIST example was not quite following the same procedure. In this fix, the testing part of the graph definition is moved out of the session to follow the procedure described in the course.