### PR TITLE
Fix one-hot encoding

### DIFF
--- a/examples/11_char_rnn_gist.py
+++ b/examples/11_char_rnn_gist.py
@@ -59,7 +59,7 @@ def create_rnn(seq, hidden_size=HIDDEN_SIZE):
     return output, in_state, out_state
 
 def create_model(seq, temp, vocab, hidden=HIDDEN_SIZE):
-    seq = tf.one_hot(seq, len(vocab))
+    seq = tf.one_hot(seq - 1, len(vocab))
     output, in_state, out_state = create_rnn(seq, hidden)
     # fully_connected is syntactic sugar for tf.matmul(w, output) + b
     # it will create w and b for us


### PR DESCRIPTION
LT;DR: length calculation is wrong, padded zeros are never ignored.

Note that `vocab_encode` encodes the each char an index in `1`..`vocab_len`: that's what is stored in `seq` before it goes through one-hot encodding. It is expected that `tf.one_hot` will encode only valid indices and return zeros for paddings (which is `0`), but it's not what it does. Instead, it will encode every index in `0`..`vocab_len-1` and ignore `vocab_len`. This means that `}` char will always end the seq, while padded zeros are processed as normal chars.

Doing `seq - 1` fixes both the padding `0` (should be invalid) and `vocab_len` (should be valid) indices.