### PR TITLE
Hotfix mnist sess run

### DIFF
--- a/examples/03_logistic_regression_mnist_sol.py
+++ b/examples/03_logistic_regression_mnist_sol.py
@@ -83,7 +83,7 @@ with tf.Session() as sess:
 	
 	for i in range(n_batches):
 		X_batch, Y_batch = mnist.test.next_batch(batch_size)
-		accuracy_batch = sess.run([accuracy], feed_dict={X: X_batch, Y:Y_batch}) 
+		accuracy_batch = sess.run(accuracy, feed_dict={X: X_batch, Y:Y_batch})
 		total_correct_preds += accuracy_batch	
 	
 	print('Accuracy {0}'.format(total_correct_preds/mnist.test.num_examples))

--- a/examples/03_logistic_regression_mnist_starter.py
+++ b/examples/03_logistic_regression_mnist_starter.py
@@ -82,7 +82,7 @@ with tf.Session() as sess:
 	
 	for i in range(n_batches):
 		X_batch, Y_batch = mnist.test.next_batch(batch_size)
-		accuracy_batch = sess.run([accuracy], feed_dict={X: X_batch, Y:Y_batch}) 
+		accuracy_batch = sess.run(accuracy, feed_dict={X: X_batch, Y:Y_batch})
 		total_correct_preds += accuracy_batch	
 	
 	print('Accuracy {0}'.format(total_correct_preds/mnist.test.num_examples))


### PR DESCRIPTION
The current example MNIST code has this line in it:

```
accuracy_batch = sess.run([accuracy], feed_dict={X: X_batch, Y:Y_batch})
```

This gives error (attempting to add a `list` to an `int`):

```
---> 33     total_correct_preds += accuracy_batch
     34   print('Accuracy {0}'.format(total_correct_preds/mnist.test.num_examples))
     35

TypeError: unsupported operand type(s) for +: 'int' and 'list'
```

This hotfix fixes it, by ensuring we are parsing a tensor object (instead of a list of 1 tensor object). i.e.

```
accuracy = sess.run(accuracy, ...)
```

Note: Parsing a list is only appropriate when we are parsing multiple tensor objects. i.e. the following would work (and produce no error):

```
accuracy_1, accuracy_2 = sess.run([accuracy, accuracy], ...)
```
